### PR TITLE
Migrate to Spectre.Console.Cli

### DIFF
--- a/Thaliak.AdminCli/Program.cs
+++ b/Thaliak.AdminCli/Program.cs
@@ -2,7 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using Serilog.Events;
-using Spectre.Cli.Extensions.DependencyInjection;
+using Spectre.Console.Cli.Extensions.DependencyInjection;
 using Spectre.Console.Cli;
 using Thaliak.AdminCli.Commands.Analysis;
 using Thaliak.Common.Database;

--- a/Thaliak.AdminCli/Thaliak.AdminCli.csproj
+++ b/Thaliak.AdminCli/Thaliak.AdminCli.csproj
@@ -15,8 +15,9 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0"/>
         <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0"/>
-        <PackageReference Include="Spectre.Cli.Extensions.DependencyInjection" Version="0.4.0"/>
-        <PackageReference Include="Spectre.Console" Version="0.44.0"/>
+        <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.1.0"/>
+        <PackageReference Include="Spectre.Console" Version="0.45.0"/>
+        <PackageReference Include="Spectre.Console.Cli" Version="0.45.0"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Spectre.Console has removed CLI functions into its own Spectre.Console.Cli NuGet package, this PR addresses the changes needed to be able to adopt the latest Spectre.Console version.

* Update Spectre.Console to 0.45.0
* Add Spectre.Console.Cli 0.45.0
* Migrate from Spectre.Cli.Extensions.DependencyInjection to Spectre.Console.Cli.Extensions.DependencyInjection